### PR TITLE
銅の間の解析エラーを修復

### DIFF
--- a/src/popup/NagaList.vue
+++ b/src/popup/NagaList.vue
@@ -545,7 +545,7 @@ export default {
     // 卓名変換
     const extractTable = (tableName) => {
       if (tableName.includes('銅')) {
-        return 'blonze';
+        return 'bronze';
       } else if (tableName.includes('銀')) {
         return 'silver';
       } else if (tableName.includes('金')) {


### PR DESCRIPTION
# 概要
銅の間の牌譜をNAGAにかけようとすると、牌譜情報が undefined になってしまう問題を修正しました。

# 詳細
タイポを修正しました。
`blonze` -> `bronze`