### PR TITLE
デュアルレビューで合意したコードスメル10件を修正

### DIFF
--- a/src/content-scripts/dd.ts
+++ b/src/content-scripts/dd.ts
@@ -90,7 +90,7 @@
                 //should treat tsumo loss as ron, luckily all yakuman values round safely for north bisection
                 delta[liableseat] -= 2 * hb + liablefor * 2 * YSCORE[OYA][KO] + tlround(TSUMO_LOSS_BISECTION * liablefor * YSCORE[OYA][KO]);
                 delta.forEach((_e, i) => {
-                    if (liableseat != i && h.seat != i && k.nplayers >= i)
+                    if (liableseat != i && h.seat != i)
                         delta[i] += hb + liablefor * YSCORE[OYA][KO] + tlround(TSUMO_LOSS_BISECTION * liablefor * (YSCORE[OYA][KO]));
                 });
                 if (3 == k.nplayers)
@@ -99,7 +99,7 @@
             else {
                 delta[liableseat] -= (k.nplayers - 2) * hb + liablefor * (YSCORE[KO][OYA] + YSCORE[KO][KO]) + tlround(TSUMO_LOSS_BISECTION * liablefor * YSCORE[KO][KO]);
                 delta.forEach((_e, i) => {
-                    if (liableseat != i && h.seat != i && k.nplayers >= i) {
+                    if (liableseat != i && h.seat != i) {
                         if (k.dealerseat == i)
                             delta[i] += hb + liablefor * YSCORE[KO][OYA] + tlround(TSUMO_LOSS_BISECTION * liablefor * YSCORE[KO][KO]);
                         else
@@ -115,23 +115,23 @@
     }
 
     function formatScoreLabel(h: any, points: string | number): string {
-        points += RUNES.points[JPNAME] + ((h.zimo && h.qinjia) ? RUNES.all[NAMEPREF] : "");
+        const label = points + RUNES.points[JPNAME] + ((h.zimo && h.qinjia) ? RUNES.all[NAMEPREF] : "");
         const fuhan = h.fu + RUNES.fu[JPNAME] + h.count + RUNES.han[JPNAME];
         if (h.yiman)
-            return (SHOWFU ? fuhan : "") + RUNES.yakuman[JPNAME] + points;
+            return (SHOWFU ? fuhan : "") + RUNES.yakuman[JPNAME] + label;
         if (13 <= h.count)
-            return (SHOWFU ? fuhan : "") + RUNES.kazoeyakuman[JPNAME] + points;
+            return (SHOWFU ? fuhan : "") + RUNES.kazoeyakuman[JPNAME] + label;
         if (11 <= h.count)
-            return (SHOWFU ? fuhan : "") + RUNES.sanbaiman[JPNAME] + points;
+            return (SHOWFU ? fuhan : "") + RUNES.sanbaiman[JPNAME] + label;
         if (8 <= h.count)
-            return (SHOWFU ? fuhan : "") + RUNES.baiman[JPNAME] + points;
+            return (SHOWFU ? fuhan : "") + RUNES.baiman[JPNAME] + label;
         if (6 <= h.count)
-            return (SHOWFU ? fuhan : "") + RUNES.haneman[JPNAME] + points;
+            return (SHOWFU ? fuhan : "") + RUNES.haneman[JPNAME] + label;
         if (5 <= h.count || (4 <= h.count && 40 <= h.fu) || (3 <= h.count && 70 <= h.fu))
-            return (SHOWFU ? fuhan : "") + RUNES.mangan[JPNAME] + points;
+            return (SHOWFU ? fuhan : "") + RUNES.mangan[JPNAME] + label;
         if (ALLOW_KIRIAGE && ((4 == h.count && 30 == h.fu) || (3 == h.count && 60 == h.fu)))
-            return (SHOWFU ? fuhan : "") + RUNES.kiriagemangan[JPNAME] + points;
-        return fuhan + points;
+            return (SHOWFU ? fuhan : "") + RUNES.kiriagemangan[JPNAME] + label;
+        return fuhan + label;
     }
 
     //parse mjs hule into tenhou agari list
@@ -322,7 +322,7 @@
             name: players.name,
             sc,
             title: [
-                ruledisp + lobby,
+                rule.disp + lobby,
                 (new Date(record.head.end_time * 1000)).toLocaleString()
             ],
         };

--- a/src/lib/naga.ts
+++ b/src/lib/naga.ts
@@ -62,13 +62,14 @@ type KyokuResult = KyokuResultAgari | KyokuResultDraw;
 function parseKyokuResult(resultEntry: TenhouLog): KyokuResult {
     if (resultEntry[0] === "和了") {
         const agaris: AgariInfo[] = [];
-        for (let t = 1; t < ~~(resultEntry.length / 2) + 1; t++) {
-            const seats = resultEntry[2 * t];
+        for (let t = 1; t + 1 < resultEntry.length; t += 2) {
+            const seats = resultEntry[t + 1];
             agaris.push({
                 isTsumo: seats[0] === seats[1],
                 winnerSeat: seats[0],
                 loserSeat: seats[1],
-                deltas: resultEntry[2 * t - 1],
+                // 元配列への参照を保持する。fixScoreRonTileWasReachTile がこの参照経由で message.log を書き換える
+                deltas: resultEntry[t],
             });
         }
         return { type: "和了", agaris };

--- a/src/lib/naga.ts
+++ b/src/lib/naga.ts
@@ -110,7 +110,7 @@ interface TenhouMessage {
     rule: { disp: string; aka53: number; aka52: number; aka51: number };
     lobby: number;
     dan: string[];
-    rate: number[];
+    rate: string[];
     sx: string[];
     name: string[];
     sc: number[];
@@ -124,10 +124,8 @@ interface GameMessage {
 /**
  * リーチ宣言牌がロンの場合を判定
  */
-function checkRonTileIsReachTile(message: GameMessage, i: number, t: number): boolean {
-    const result = parseKyokuResult(message.log[i][16]) as KyokuResultAgari;
-    const agari = result.agaris[t - 1];
-    const targetArray = getDiscardsForSeat(message.log[i], agari.loserSeat);
+function checkRonTileIsReachTile(logEntry: TenhouLog, agari: AgariInfo): boolean {
+    const targetArray = getDiscardsForSeat(logEntry, agari.loserSeat);
     const targetPointEven = agari.deltas[agari.loserSeat] === agari.deltas[agari.winnerSeat];
     if (targetArray && !targetPointEven) {
         const lastElement = targetArray[targetArray.length - 1];
@@ -147,7 +145,7 @@ function fixScoreRonTileWasReachTile(message: GameMessage): void {
         for (let t = 0; t < agaris.length; t++) {
             const agari = agaris[t];
             if (!agari.isTsumo) {
-                if (checkRonTileIsReachTile(message, i, t + 1)) {
+                if (checkRonTileIsReachTile(message.log[i], agari)) {
                     agari.deltas[agari.winnerSeat] -= 1000;
                 }
             }

--- a/src/popup/NagaList.vue
+++ b/src/popup/NagaList.vue
@@ -210,7 +210,6 @@ const handleRuleChange = (event: Event) => {
   const value = (event.target as HTMLSelectElement).value;
   Rule.value = value;
   chrome.storage.local.set({ rule: value });
-  location.reload();
 };
 /* eslint-enable @typescript-eslint/no-explicit-any */
 </script>

--- a/src/popup/NagaList.vue
+++ b/src/popup/NagaList.vue
@@ -42,7 +42,7 @@
 import { onMounted, onUnmounted, reactive, ref, computed } from "vue";
 import Kyoku from "@/popup/Kyoku.vue";
 import { fixScoreRonTileWasReachTile, parseKyokuResult } from "@/lib/naga";
-import type { TenhouMessage, KyokuResultAgari } from "@/lib/naga";
+import type { TenhouMessage, KyokuResultAgari, KyokuResultDraw } from "@/lib/naga";
 import { sanitizePlayerNames, soul2naga } from "@/lib/viewer";
 import { useDisplayLang } from "@/composables/useDisplayLang";
 
@@ -168,8 +168,9 @@ const processData = (message: TenhouMessage) => {
       }
     } else {
       const ryukyoku: any[] = [parsed.type];
-      if ((parsed as { deltas: number[] | null }).deltas) {
-        (parsed as { deltas: number[] }).deltas.forEach((score: number, index: number) => {
+      const draw = parsed as KyokuResultDraw;
+      if (draw.deltas) {
+        draw.deltas.forEach((score: number, index: number) => {
           if (score > 0) {
             ryukyoku.push(message.name[index])
           }

--- a/tests/naga.test.ts
+++ b/tests/naga.test.ts
@@ -1,5 +1,5 @@
 import { extractTable, toSoulTable, toNagaHand, toNagaLog, parseKyokuResult, checkRonTileIsReachTile, fixScoreRonTileWasReachTile, getDrawsForSeat, getDiscardsForSeat, getScoreAndBonus } from "../src/lib/naga";
-import type { KyokuResultAgari, KyokuResultDraw } from "../src/lib/naga";
+import type { KyokuResultAgari, KyokuResultDraw, AgariInfo } from "../src/lib/naga";
 
 describe("extractTable", () => {
     test("bronze room", () => {
@@ -92,24 +92,21 @@ describe("toNagaLog", () => {
 
 describe("checkRonTileIsReachTile", () => {
     test("returns true when last discard starts with r", () => {
-        const message = {
-            log: [buildRonLog({ lastDiscard: "r15", winnerDelta: 8000, loserDelta: -8000 })]
-        };
-        expect(checkRonTileIsReachTile(message, 0, 1)).toBe(true);
+        const log = buildRonLog({ lastDiscard: "r15", winnerDelta: 8000, loserDelta: -8000 });
+        const agari = (parseKyokuResult(log[16]) as KyokuResultAgari).agaris[0];
+        expect(checkRonTileIsReachTile(log, agari)).toBe(true);
     });
 
     test("returns false when last discard is not riichi", () => {
-        const message = {
-            log: [buildRonLog({ lastDiscard: 15, winnerDelta: 8000, loserDelta: -8000 })]
-        };
-        expect(checkRonTileIsReachTile(message, 0, 1)).toBe(false);
+        const log = buildRonLog({ lastDiscard: 15, winnerDelta: 8000, loserDelta: -8000 });
+        const agari = (parseKyokuResult(log[16]) as KyokuResultAgari).agaris[0];
+        expect(checkRonTileIsReachTile(log, agari)).toBe(false);
     });
 
     test("returns false when point difference is even (double ron)", () => {
-        const message = {
-            log: [buildRonLog({ lastDiscard: "r15", winnerDelta: 8000, loserDelta: 8000 })]
-        };
-        expect(checkRonTileIsReachTile(message, 0, 1)).toBe(false);
+        const log = buildRonLog({ lastDiscard: "r15", winnerDelta: 8000, loserDelta: 8000 });
+        const agari = (parseKyokuResult(log[16]) as KyokuResultAgari).agaris[0];
+        expect(checkRonTileIsReachTile(log, agari)).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary
- Claude + Codex のデュアルレビューで両者が合意した指摘を修正
- dd.ts: Pao支払い計算の条件式修正、formatScoreLabelの引数ミューテーション解消、title生成時の変数参照ミス修正
- naga.ts: parseKyokuResultのループを安全なイテレーションに変更、deltas参照依存をコメントで明記、checkRonTileIsReachTileのシグネチャ改善
- NagaList.vue: 型安全性向上、ルール変更時のlocation.reload()削除

## Test plan
- [x] 全118テスト通過確認済み
- [ ] ルール変更時に取得済みデータが保持されることを手動確認

## Additional update
- NagaList.vue: 友人戦・大会戦で牌譜取得後にルールを変更した場合でも、送信する NAGA URL が最新のルール設定に追従するよう修正
- `toNagaData` を可変状態ではなく、最新の牌譜データと `Rule` から導出する形に整理

## Additional verification
- [x] `npm run build`