### PR TITLE
fix: fetchGameRecord判定をWrapper.name完全一致に変更 (v1.5.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mahjongsoul-review-helper",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "wxt",

--- a/src/lib/ws-capture.ts
+++ b/src/lib/ws-capture.ts
@@ -30,7 +30,10 @@ export class GameRecordCapturer {
   // 送信フレームを観測。fetchGameRecordリクエストならそのindexを覚える。
   observeSend(data: Uint8Array): void {
     if (data.length < 3 || data[0] !== FRAME_REQUEST) return;
-    if (containsAscii(data, "fetchGameRecord")) {
+    // Wrapper.name 直後に来る data field tag(0x12)まで含めて完全一致させる。
+    // 単に "fetchGameRecord" だけだと fetchGameRecordList / fetchGameRecordsDetail にも一致してしまい、
+    // それらの応答(head フィールドを持たない別型)を捕捉して record-decode 側で "head missing" に至っていた。
+    if (containsAscii(data, "fetchGameRecord\x12")) {
       this.pendingIndex = frameIndex(data);
     }
   }

--- a/tests/ws-capture.test.ts
+++ b/tests/ws-capture.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { GameRecordCapturer, containsAscii, frameIndex } from "../src/lib/ws-capture";
 
-// "fetchGameRecord" のASCIIバイト列を任意位置に埋め込んだリクエストフレームを作る。
-function makeRequest(index: number, includeName = true): Uint8Array {
-  const name = includeName ? "fetchGameRecord" : "heartbeat";
-  const bytes = [0x02, index & 0xff, (index >> 8) & 0xff, 0x0a];
-  for (let i = 0; i < name.length; i++) bytes.push(name.charCodeAt(i));
-  return new Uint8Array(bytes);
+// Wrapper の wire format に沿ったリクエストフレームを作る。
+// [type=0x02][index_lo][index_hi][name field 0x0a][name_len][name bytes][data field 0x12][data_len=0]。
+// fetchGameRecord と fetchGameRecordList のように prefix が共通する RPC を区別できる形にする必要があるため、
+// name 直後の data field tag(0x12)まで含めた実フレーム相当のバイト列を組む。
+function makeRequest(index: number, methodName: string | null = "fetchGameRecord"): Uint8Array {
+  const header = [0x02, index & 0xff, (index >> 8) & 0xff];
+  if (methodName === null) return new Uint8Array([...header, 0x12, 0x00]);
+  const nameBytes: number[] = [];
+  for (let i = 0; i < methodName.length; i++) nameBytes.push(methodName.charCodeAt(i));
+  return new Uint8Array([...header, 0x0a, methodName.length, ...nameBytes, 0x12, 0x00]);
 }
 
 function makeResponse(index: number, type = 0x03): ArrayBuffer {
@@ -62,8 +66,37 @@ describe("GameRecordCapturer", () => {
 
   it("fetchGameRecord以外のリクエスト後の応答は捕捉しない", () => {
     const capturer = new GameRecordCapturer();
-    capturer.observeSend(makeRequest(42, false));
+    capturer.observeSend(makeRequest(42, "heartbeat"));
     capturer.observeRecv(makeResponse(42));
     expect(capturer.latest()).toBeNull();
+  });
+
+  // fetchGameRecordList / fetchGameRecordsDetail は wire name に "fetchGameRecord" を含むが
+  // レスポンス型(ResGameRecordList 等)が異なり head フィールドを持たないため、
+  // これらの応答を捕捉してしまうと record-decode 側で "head missing" となる。
+  it("fetchGameRecordList リクエスト後の応答は捕捉しない", () => {
+    const capturer = new GameRecordCapturer();
+    capturer.observeSend(makeRequest(42, "fetchGameRecordList"));
+    capturer.observeRecv(makeResponse(42));
+    expect(capturer.latest()).toBeNull();
+  });
+
+  it("fetchGameRecordsDetail リクエスト後の応答は捕捉しない", () => {
+    const capturer = new GameRecordCapturer();
+    capturer.observeSend(makeRequest(42, "fetchGameRecordsDetail"));
+    capturer.observeRecv(makeResponse(42));
+    expect(capturer.latest()).toBeNull();
+  });
+
+  // 他人の牌譜閲覧時に発生していた、fetchGameRecord 応答取得後に
+  // fetchGameRecordsDetail 等の応答で this.record が上書きされる事象の回帰防止。
+  it("fetchGameRecord 応答取得後に来る別RPC応答で上書きされない", () => {
+    const capturer = new GameRecordCapturer();
+    capturer.observeSend(makeRequest(10, "fetchGameRecord"));
+    const recordResponse = makeResponse(10);
+    capturer.observeRecv(recordResponse);
+    capturer.observeSend(makeRequest(11, "fetchGameRecordsDetail"));
+    capturer.observeRecv(makeResponse(11));
+    expect(capturer.latest()).toBe(recordResponse);
   });
 });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     modules: ["@wxt-dev/module-vue"],
     manifest: {
         name: "__MSG_appName__",
-        version: "1.5.0",
+        version: "1.5.1",
         description: "__MSG_appDesc__",
         author: "kbkn",
         default_locale: "en",


### PR DESCRIPTION
## Summary
- 他人の牌譜閲覧時に `decode/parse failed Error: not a fetchGameRecord response (head missing)` が発生する不具合を修正
- 根本原因: `ws-capture.ts` のリクエスト判定が部分文字列マッチ (`containsAscii(data, "fetchGameRecord")`) で、`fetchGameRecordList` / `fetchGameRecordsDetail` など同 prefix の RPC も誤って捕捉対象にしていた。これらが `fetchGameRecord` 応答後に走ると `this.record` が上書きされ、`head` フィールドを持たない別型を `ResGameRecord.decode` していた (regression: 711eb6a)
- 修正: Wrapper の `name` 直後に来る data field tag (`0x12`) まで含めた `"fetchGameRecord\x12"` で判定し、同 prefix の別 RPC を確実に弾く
- バージョンを 1.5.1 に更新

## Test plan
- [x] `npx vitest run tests/ws-capture.test.ts` — 新規 3 ケース (`fetchGameRecordList` / `fetchGameRecordsDetail` リクエスト後の応答を捕捉しない、`fetchGameRecord` 応答取得後に別 RPC 応答で上書きされない) を含む 11 件すべて pass
- [x] `npx vitest run` — 全 137 テスト pass、回帰なし
- [x] `npm run build` — ビルド成功
- [ ] 実機: ログインユーザー自身の牌譜が引き続き解析可能なこと
- [ ] 実機: 他ユーザーの牌譜で `head missing` エラーが消え、解析が成功すること