### PR TITLE
docs: tensoulのURLをEquim-chan/tensoulに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project includes code and concepts from:
 * mjai-reviewer : [Github Equim-chan/mjai-reviewer](https://github.com/Equim-chan/mjai-reviewer)
   * Apache-2.0 Using `downloadlogs script`
   * The actual reference in this project is [dd.js](src/content-scripts/dd.js)
-* tensoul : [Github tomohxx/tensoul](https://github.com/tomohxx/tensoul)
+* tensoul : [Github Equim-chan/tensoul](https://github.com/Equim-chan/tensoul)
   * MIT - Referenced for the Mahjong Soul CDN version resolution method
 * MajsoulMax : [Github Avenshy/MajsoulMax](https://github.com/Avenshy/MajsoulMax)
   * GPL-3.0 - Referenced for the liqi WebSocket frame structure (no code copied)


### PR DESCRIPTION
## Summary
- README の Credits にある tensoul のリンクが誤っていたため修正 (Fixes #34)
- 誤: `tomohxx/tensoul` → 正: `Equim-chan/tensoul`（リンクテキストと URL の両方）

## Test plan
- [ ] README.md のリンクが https://github.com/Equim-chan/tensoul を指していることを確認